### PR TITLE
Fix parameters for VIES country code, check for error page on isvat

### DIFF
--- a/app/code/community/Redkiwi/Rkvatfallback/Helper/Data.php
+++ b/app/code/community/Redkiwi/Rkvatfallback/Helper/Data.php
@@ -83,7 +83,7 @@ class Redkiwi_Rkvatfallback_Helper_Data extends Mage_Customer_Helper_Data
 				curl_close($ch);
 			}
 			
-			if (strstr($body, 'true'))
+			if (strstr($body, 'true') && !strstr($body, '<html'))
 			{
 				$gatewayResponse->setIsValid(true);
 				$gatewayResponse->setRequestDate(date('Y/m/d H:i:s'));

--- a/app/code/community/Redkiwi/Rkvatfallback/Helper/Data.php
+++ b/app/code/community/Redkiwi/Rkvatfallback/Helper/Data.php
@@ -15,96 +15,96 @@ class Redkiwi_Rkvatfallback_Helper_Data extends Mage_Customer_Helper_Data
      */
     public function checkVatNumber($countryCode, $vatNumber, $requesterCountryCode = '', $requesterVatNumber = '')
     {
-		$gatewayResponse = parent::checkVatNumber($countryCode, $vatNumber, $requesterCountryCode, $requesterVatNumber);
-	
-		$requestParams = array();
-		$requestParams['countryCode'] = $countryCode;
-		$requestParams['vatNumber'] = str_replace(array(' ', '-'), array('', ''), $vatNumber);
-		$requestParams['requesterCountryCode'] = $requesterCountryCode;
-		$requestParams['requesterVatNumber'] = str_replace(array(' ', '-'), array('', ''), $requesterVatNumber);
+        $gatewayResponse = parent::checkVatNumber($countryCode, $vatNumber, $requesterCountryCode, $requesterVatNumber);
+    
+        $requestParams = array();
+        $requestParams['countryCode'] = $countryCode;
+        $requestParams['vatNumber'] = str_replace(array(' ', '-'), array('', ''), $vatNumber);
+        $requestParams['requesterCountryCode'] = $requesterCountryCode;
+        $requestParams['requesterVatNumber'] = str_replace(array(' ', '-'), array('', ''), $requesterVatNumber);
 
-                $result = $gatewayResponse->getIsValid();
+        $result = $gatewayResponse->getIsValid();
 
-		// try the EU VIES website
-		if (!$result && Mage::getStoreConfig('customer/vat_services/vies_validation'))
-		{
-			$vat_url = 'http://ec.europa.eu/taxation_customs/vies/viesquer.do?';
-			$vat_url .= http_build_query(array(
-                'ms'			=> $requestParams['countryCode'],
-                'iso'			=> $requestParams['countryCode'],
-                'vat'			=> $requestParams['vatNumber'],
+        // try the EU VIES website
+        if (!$result && Mage::getStoreConfig('customer/vat_services/vies_validation'))
+        {
+            $vat_url = 'http://ec.europa.eu/taxation_customs/vies/viesquer.do?';
+            $vat_url .= http_build_query(array(
+                'ms'            => $requestParams['countryCode'],
+                'iso'            => $requestParams['countryCode'],
+                'vat'            => $requestParams['vatNumber'],
                 'requesterMs'   => $requestParams['requesterCountryCode'],
                 'requesterIso'  => $requestParams['requesterCountryCode'],
                 'requesterVat'  => $requestParams['requesterVatNumber'],
-				'BtnSubmitVat'	=> 'Verify',
-			), '', '&');
-			
-			$body = '';
-			if ($ch = curl_init())
-			{
-				curl_setopt($ch, CURLOPT_URL, $vat_url);
-				curl_setopt($ch, CURLOPT_HEADER, 0);
-				curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
-				curl_setopt($ch, CURLOPT_FOLLOWLOCATION, 1);
-				curl_setopt($ch, CURLOPT_MAXREDIRS, 3);
-				curl_setopt($ch, CURLOPT_TIMEOUT, 3);
+                'BtnSubmitVat'    => 'Verify',
+            ), '', '&');
+            
+            $body = '';
+            if ($ch = curl_init())
+            {
+                curl_setopt($ch, CURLOPT_URL, $vat_url);
+                curl_setopt($ch, CURLOPT_HEADER, 0);
+                curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+                curl_setopt($ch, CURLOPT_FOLLOWLOCATION, 1);
+                curl_setopt($ch, CURLOPT_MAXREDIRS, 3);
+                curl_setopt($ch, CURLOPT_TIMEOUT, 3);
 
-				$body = curl_exec($ch);
-				curl_close($ch);
-			}
-			
-			if (strstr($body, '<span class="validStyle">'))
-			{
-				$gatewayResponse->setIsValid(true);
-				$gatewayResponse->setRequestDate(date('Y/m/d H:i:s'));
-				$gatewayResponse->setRequestIdentifier('');
-				$gatewayResponse->setRequestSuccess(true);
-			}
+                $body = curl_exec($ch);
+                curl_close($ch);
+            }
+            
+            if (strstr($body, '<span class="validStyle">'))
+            {
+                $gatewayResponse->setIsValid(true);
+                $gatewayResponse->setRequestDate(date('Y/m/d H:i:s'));
+                $gatewayResponse->setRequestIdentifier('');
+                $gatewayResponse->setRequestSuccess(true);
+            }
 
-                        $result = $gatewayResponse->getIsValid();
-		}
-		
-		// try the Isvat Appspot API
-                if (!$result && Mage::getStoreConfig('customer/vat_services/isvat_validation'))
-		{
-			$vat_url = "http://isvat.appspot.com/{$requestParams['countryCode']}/{$requestParams['vatNumber']}/";
-			
-			$body = '';
-			if ($ch = curl_init())
-			{
-				curl_setopt($ch, CURLOPT_URL, $vat_url);
-				curl_setopt($ch, CURLOPT_HEADER, 0);
-				curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
-				curl_setopt($ch, CURLOPT_FOLLOWLOCATION, 1);
-				curl_setopt($ch, CURLOPT_MAXREDIRS, 3);
-				curl_setopt($ch, CURLOPT_TIMEOUT, 3);
+            $result = $gatewayResponse->getIsValid();
+        }
+        
+        // try the Isvat Appspot API
+        if (!$result && Mage::getStoreConfig('customer/vat_services/isvat_validation'))
+        {
+            $vat_url = "http://isvat.appspot.com/{$requestParams['countryCode']}/{$requestParams['vatNumber']}/";
+            
+            $body = '';
+            if ($ch = curl_init())
+            {
+                curl_setopt($ch, CURLOPT_URL, $vat_url);
+                curl_setopt($ch, CURLOPT_HEADER, 0);
+                curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+                curl_setopt($ch, CURLOPT_FOLLOWLOCATION, 1);
+                curl_setopt($ch, CURLOPT_MAXREDIRS, 3);
+                curl_setopt($ch, CURLOPT_TIMEOUT, 3);
 
-				$body = curl_exec($ch);
-				curl_close($ch);
-			}
-			
-			if (strstr($body, 'true') && !strstr($body, '<html'))
-			{
-				$gatewayResponse->setIsValid(true);
-				$gatewayResponse->setRequestDate(date('Y/m/d H:i:s'));
-				$gatewayResponse->setRequestIdentifier('');
-				$gatewayResponse->setRequestSuccess(true);
-			}
+                $body = curl_exec($ch);
+                curl_close($ch);
+            }
+            
+            if (strstr($body, 'true') && !strstr($body, '<html'))
+            {
+                $gatewayResponse->setIsValid(true);
+                $gatewayResponse->setRequestDate(date('Y/m/d H:i:s'));
+                $gatewayResponse->setRequestIdentifier('');
+                $gatewayResponse->setRequestSuccess(true);
+            }
 
-                        $result = $gatewayResponse->getIsValid();
-		}
+            $result = $gatewayResponse->getIsValid();
+        }
 
-                // Try regex
-                if (!$result && Mage::getStoreConfig('customer/vat_services/regex_validation'))
-                {
-                    $gatewayResponse->setIsValid($this->vatRegexCheck($requestParams['vatNumber'], $requestParams['countryCode']));
-                    $gatewayResponse->setRequestDate(date('Y/m/d H:i:s'));
-                    $gatewayResponse->setRequestIdentifier('');
-                    $gatewayResponse->setRequestSuccess(true);
-                }
-		
-		return $gatewayResponse;
-	}
+        // Try regex
+        if (!$result && Mage::getStoreConfig('customer/vat_services/regex_validation'))
+        {
+            $gatewayResponse->setIsValid($this->vatRegexCheck($requestParams['vatNumber'], $requestParams['countryCode']));
+            $gatewayResponse->setRequestDate(date('Y/m/d H:i:s'));
+            $gatewayResponse->setRequestIdentifier('');
+            $gatewayResponse->setRequestSuccess(true);
+        }
+        
+        return $gatewayResponse;
+    }
 
     /**
      * Based on rules in http://ec.europa.eu/taxation_customs/vies/faqvies.do

--- a/app/code/community/Redkiwi/Rkvatfallback/Helper/Data.php
+++ b/app/code/community/Redkiwi/Rkvatfallback/Helper/Data.php
@@ -30,9 +30,12 @@ class Redkiwi_Rkvatfallback_Helper_Data extends Mage_Customer_Helper_Data
 		{
 			$vat_url = 'http://ec.europa.eu/taxation_customs/vies/viesquer.do?';
 			$vat_url .= http_build_query(array(
-				'ms'			=> $requestParams['requesterCountryCode'],
-				'iso'			=> $requestParams['countryCode'],
-				'vat'			=> $requestParams['vatNumber'],
+                'ms'			=> $requestParams['countryCode'],
+                'iso'			=> $requestParams['countryCode'],
+                'vat'			=> $requestParams['vatNumber'],
+                'requesterMs'   => $requestParams['requesterCountryCode'],
+                'requesterIso'  => $requestParams['requesterCountryCode'],
+                'requesterVat'  => $requestParams['requesterVatNumber'],
 				'BtnSubmitVat'	=> 'Verify',
 			), '', '&');
 			


### PR DESCRIPTION
The parameters for the http://ec.europa.eu/taxation_customs/vies/viesquer.do method need to have the validated number country code under 'ms', not the requesting country code. Also, I ran into an error page on the isvat service that returns a false positive (a deadline exceeded html error page), so I added a check for any html before returning true.

Finally, i replaced the tabs with spaces since there was a mix of both.